### PR TITLE
Fill NWB metadata

### DIFF
--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrer_ophys_metadata.yml
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrer_ophys_metadata.yml
@@ -1,9 +1,16 @@
 NWBFile:
-  session_description: >
-    A rich text description of the experiment. Can also just be the abstract of the publication.
+  session_description: Mouse exploring
   institution: Massachusetts Institute of Technology
   lab: Fee Lab
   experimenter:
     - Scherrer, Joseph
+  virus: GCaMP7f
+  surgery: >
+    4mm glass window implant over right visual and somatosensory cortex
 Subject:
-  species: Rattus norvegicus
+  subject_id: 4mm mouse 1
+  genotype: C57/B6
+  species: Mus musculus
+  sex: M
+  age: P3M # 3 months in ISO 8601 duration format
+  description: ~20 virus injections in layer 2/3 of cortex


### PR DESCRIPTION
Fill metadata with extended information about the session and the experimental subject.

Output in an example NWB file:

<img width="791" alt="Screenshot 2022-05-27 at 13 42 44" src="https://user-images.githubusercontent.com/24475788/170692887-fffc287d-b1df-4ce5-92f6-be3446a165e3.png">
<img width="777" alt="Screenshot 2022-05-27 at 13 45 16" src="https://user-images.githubusercontent.com/24475788/170693175-0d03fb99-5a6a-4029-ba0e-a460b259c7fb.png">

