### PR TITLE
Convert imaging data

### DIFF
--- a/src/fee_lab_to_nwb/scherrer_ophys/__init__.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/__init__.py
@@ -1,1 +1,2 @@
 from .scherrerophysnwbconverter import ScherrerOphysNWBConverter
+from .scherrerophysimagingextractor import ScherrerOphysImagingExtractor

--- a/src/fee_lab_to_nwb/scherrer_ophys/__init__.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/__init__.py
@@ -1,2 +1,1 @@
 from .scherrerophysnwbconverter import ScherrerOphysNWBConverter
-from .scherrerophysimagingextractor import ScherrerOphysImagingExtractor

--- a/src/fee_lab_to_nwb/scherrer_ophys/convert_session.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/convert_session.py
@@ -5,10 +5,7 @@ from zoneinfo import ZoneInfo
 
 from nwb_conversion_tools.utils import load_dict_from_file, dict_deep_update
 
-from fee_lab_to_nwb.scherrer_ophys import (
-    ScherrerOphysNWBConverter,
-    ScherrerOphysImagingExtractor,
-)
+from fee_lab_to_nwb.scherrer_ophys import ScherrerOphysNWBConverter
 from utils import get_timestamps_from_csv
 
 # The base folder path for ophys data
@@ -36,13 +33,10 @@ nwbfile_path = behavior_movie_file_path.parent / f"{nwb_file_name}.nwb"
 metadata_path = Path(__file__).parent / "scherrer_ophys_metadata.yml"
 metadata_from_yaml = load_dict_from_file(metadata_path)
 
-imaging_extractors = [
-    ScherrerOphysImagingExtractor(file_path=file_path) for file_path in ophys_file_paths
-]
 ophys_timestamps = get_timestamps_from_csv(file_path=ophys_timestamp_file_path)
 source_data = dict(
     Movie=dict(file_paths=[behavior_movie_file_path]),
-    Ophys=dict(imaging_extractors=imaging_extractors, timestamps=ophys_timestamps),
+    Ophys=dict(file_paths=ophys_file_paths, timestamps=ophys_timestamps),
 )
 
 timestamps = get_timestamps_from_csv(file_path=behavior_data_file_path)

--- a/src/fee_lab_to_nwb/scherrer_ophys/convert_session.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/convert_session.py
@@ -33,10 +33,12 @@ nwbfile_path = behavior_movie_file_path.parent / f"{nwb_file_name}.nwb"
 metadata_path = Path(__file__).parent / "scherrer_ophys_metadata.yml"
 metadata_from_yaml = load_dict_from_file(metadata_path)
 
-ophys_timestamps = get_timestamps_from_csv(file_path=ophys_timestamp_file_path)
 source_data = dict(
     Movie=dict(file_paths=[behavior_movie_file_path]),
-    Ophys=dict(file_paths=ophys_file_paths, timestamps=ophys_timestamps),
+    Ophys=dict(
+        ophys_file_paths=ophys_file_paths,
+        timestamps_file_path=str(ophys_timestamp_file_path),
+    ),
 )
 
 timestamps = get_timestamps_from_csv(file_path=behavior_data_file_path)

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -40,8 +40,6 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
             # Apply custom conversion to frames : green * 8 + blue / 8
             gray_frame = (green_color_data * 8) + (blue_color_data / 8)
             gray_frame = gray_frame.astype(np.uint16)
-            # Transpose frame to maintain original orientation after conversion
-            gray_frame = gray_frame.T
 
             frames.append(gray_frame[np.newaxis, ...])
 

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractorinterface.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractorinterface.py
@@ -7,8 +7,8 @@ from roiextractors.multiimagingextractor import MultiImagingExtractor
 class ScherrerOphysImagingExtractorInterface(BaseImagingExtractorInterface):
     IX = MultiImagingExtractor
 
-    def __init__(self, imaging_extractors: list, timestamps: list):
+    def __init__(self, imaging_extractors: list, timestamps: list, verbose: bool = True):
         super().__init__(imaging_extractors=imaging_extractors)
         self.imaging_extractor = self.IX(imaging_extractors=imaging_extractors)
         self.imaging_extractor.set_times(times=timestamps)
-        self.verbose = True
+        self.verbose = verbose

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractorinterface.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractorinterface.py
@@ -1,16 +1,23 @@
 from nwb_conversion_tools.datainterfaces.ophys.baseimagingextractorinterface import (
     BaseImagingExtractorInterface,
 )
+from nwb_conversion_tools.utils import calculate_regular_series_rate
 from roiextractors.multiimagingextractor import MultiImagingExtractor
+
+from fee_lab_to_nwb.scherrer_ophys import ScherrerOphysImagingExtractor
 
 
 class ScherrerOphysImagingExtractorInterface(BaseImagingExtractorInterface):
     IX = MultiImagingExtractor
 
-    def __init__(
-        self, imaging_extractors: list, timestamps: list, verbose: bool = True
-    ):
+    def __init__(self, file_paths: list, timestamps: list, verbose: bool = True):
+        imaging_extractors = [
+            ScherrerOphysImagingExtractor(file_path=file_path)
+            for file_path in file_paths
+        ]
         super().__init__(imaging_extractors=imaging_extractors)
         self.imaging_extractor = self.IX(imaging_extractors=imaging_extractors)
-        self.imaging_extractor.set_times(times=timestamps)
+        if not calculate_regular_series_rate(timestamps):
+            # only use timestamps if they are not regular
+            self.imaging_extractor.set_times(times=timestamps[:3000])
         self.verbose = verbose

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractorinterface.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractorinterface.py
@@ -21,5 +21,5 @@ class ScherrerOphysImagingExtractorInterface(BaseImagingExtractorInterface):
         self.imaging_extractor = self.IX(imaging_extractors=imaging_extractors)
         if not calculate_regular_series_rate(timestamps):
             # only use timestamps if they are not regular
-            self.imaging_extractor.set_times(times=timestamps[:3000])
+            self.imaging_extractor.set_times(times=timestamps)
         self.verbose = verbose

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractorinterface.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractorinterface.py
@@ -21,7 +21,6 @@ class ScherrerOphysImagingExtractorInterface(BaseImagingExtractorInterface):
             for file_path in ophys_file_paths
         ]
         super().__init__(imaging_extractors=imaging_extractors)
-        self.imaging_extractor = self.IX(imaging_extractors=imaging_extractors)
         timestamps = get_timestamps_from_csv(file_path=timestamps_file_path)
         if not calculate_regular_series_rate(timestamps):
             # only use timestamps if they are not regular

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractorinterface.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractorinterface.py
@@ -4,7 +4,9 @@ from nwb_conversion_tools.datainterfaces.ophys.baseimagingextractorinterface imp
 from nwb_conversion_tools.utils import calculate_regular_series_rate
 from roiextractors.multiimagingextractor import MultiImagingExtractor
 
-from fee_lab_to_nwb.scherrer_ophys import ScherrerOphysImagingExtractor
+from fee_lab_to_nwb.scherrer_ophys.scherrerophysimagingextractor import (
+    ScherrerOphysImagingExtractor,
+)
 
 
 class ScherrerOphysImagingExtractorInterface(BaseImagingExtractorInterface):

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractorinterface.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractorinterface.py
@@ -7,18 +7,22 @@ from roiextractors.multiimagingextractor import MultiImagingExtractor
 from fee_lab_to_nwb.scherrer_ophys.scherrerophysimagingextractor import (
     ScherrerOphysImagingExtractor,
 )
+from fee_lab_to_nwb.scherrer_ophys.utils import get_timestamps_from_csv
 
 
 class ScherrerOphysImagingExtractorInterface(BaseImagingExtractorInterface):
     IX = MultiImagingExtractor
 
-    def __init__(self, file_paths: list, timestamps: list, verbose: bool = True):
+    def __init__(
+        self, ophys_file_paths: list, timestamps_file_path: str, verbose: bool = True
+    ):
         imaging_extractors = [
             ScherrerOphysImagingExtractor(file_path=file_path)
-            for file_path in file_paths
+            for file_path in ophys_file_paths
         ]
         super().__init__(imaging_extractors=imaging_extractors)
         self.imaging_extractor = self.IX(imaging_extractors=imaging_extractors)
+        timestamps = get_timestamps_from_csv(file_path=timestamps_file_path)
         if not calculate_regular_series_rate(timestamps):
             # only use timestamps if they are not regular
             self.imaging_extractor.set_times(times=timestamps)

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractorinterface.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractorinterface.py
@@ -7,7 +7,9 @@ from roiextractors.multiimagingextractor import MultiImagingExtractor
 class ScherrerOphysImagingExtractorInterface(BaseImagingExtractorInterface):
     IX = MultiImagingExtractor
 
-    def __init__(self, imaging_extractors: list, timestamps: list, verbose: bool = True):
+    def __init__(
+        self, imaging_extractors: list, timestamps: list, verbose: bool = True
+    ):
         super().__init__(imaging_extractors=imaging_extractors)
         self.imaging_extractor = self.IX(imaging_extractors=imaging_extractors)
         self.imaging_extractor.set_times(times=timestamps)

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractorinterface.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractorinterface.py
@@ -1,39 +1,14 @@
-from typing import Optional
-
 from nwb_conversion_tools.datainterfaces.ophys.baseimagingextractorinterface import (
     BaseImagingExtractorInterface,
 )
-from nwb_conversion_tools.tools.roiextractors import write_imaging
-from nwb_conversion_tools.utils import OptionalFilePathType
-from pynwb import NWBFile
-
-from fee_lab_to_nwb.scherrer_ophys.scherrerophysimagingextractor import (
-    ScherrerOphysImagingExtractor,
-)
+from roiextractors.multiimagingextractor import MultiImagingExtractor
 
 
 class ScherrerOphysImagingExtractorInterface(BaseImagingExtractorInterface):
-    IX = ScherrerOphysImagingExtractor
+    IX = MultiImagingExtractor
 
-    def __init__(self, file_path: str):
-        super().__init__(file_path=file_path)
-        self.imaging_extractor = self.IX(file_path=file_path)
+    def __init__(self, imaging_extractors: list, timestamps: list):
+        super().__init__(imaging_extractors=imaging_extractors)
+        self.imaging_extractor = self.IX(imaging_extractors=imaging_extractors)
+        self.imaging_extractor.set_times(times=timestamps)
         self.verbose = True
-
-    def run_conversion(
-        self,
-        nwbfile_path: OptionalFilePathType = None,
-        nwbfile: Optional[NWBFile] = None,
-        metadata: Optional[dict] = None,
-        overwrite: bool = False,
-        save_path: OptionalFilePathType = None,
-    ):
-        write_imaging(
-            imaging=self.imaging_extractor,
-            nwbfile_path=nwbfile_path,
-            nwbfile=nwbfile,
-            metadata=metadata,
-            overwrite=overwrite,
-            verbose=self.verbose,
-            save_path=save_path,
-        )

--- a/src/fee_lab_to_nwb/scherrer_ophys/utils.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/utils.py
@@ -1,13 +1,17 @@
 """Utility functions for this dataset."""
 from pathlib import Path
 
+from nwb_conversion_tools.utils import FilePathType
 from pandas import read_csv, to_datetime
 
 
-def get_timestamps_from_csv(file_path: Path):
+def get_timestamps_from_csv(file_path: FilePathType):
     """
     Extracts timestamps from a file.
     """
+
+    if isinstance(file_path, str):
+        file_path = Path(file_path)
 
     assert file_path.suffix == ".csv", f"{file_path} should be a .csv"
     assert file_path.exists(), f"{file_path} does not exist"


### PR DESCRIPTION
- Switch to `MultiImagingExtractor` to convert all ophys data 
- `ScherrerOphysImagingExtractorInterface` is modified to take the list of timestamps for the ophys data
- Checked the resulting NWB File, surprisingly the image was rotated compared to the original, so the transpose is removed here
