### PR TITLE
Add `get_video` to ScherrerOphysImagingExtractor

### DIFF
--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -19,14 +19,13 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
     def __init__(self, file_path: FilePathType):
         super().__init__()
         self.file_path = file_path
-        self.video_capture_context = VideoCaptureContext(str(self.file_path))
+        self.video_capture_context = VideoCaptureContext(str(self.file_path)).__enter__()
         self._num_channels = 0
         self._channel_names = ["channel_0"]
 
-        with self.video_capture_context as vc:
-            self._num_frames = vc.get_movie_frame_count()
-            self._image_size = vc.get_frame_shape()[:-1]
-            self._sampling_frequency = vc.get_movie_fps()
+        self._num_frames = self.video_capture_context.get_movie_frame_count()
+        self._image_size = self.video_capture_context.get_frame_shape()[:-1]
+        self._sampling_frequency = self.video_capture_context.get_movie_fps()
 
     def get_frames(self, frame_idxs: ArrayType, channel: int = 0) -> NumpyArray:
         frames = []

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -57,10 +57,10 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
         return concatenated_frames
 
     def get_video(
-            self,
-            start_frame: Optional[int] = None,
-            end_frame: Optional[int] = None,
-            channel: Optional[int] = 0
+        self,
+        start_frame: Optional[int] = None,
+        end_frame: Optional[int] = None,
+        channel: Optional[int] = 0,
     ) -> np.ndarray:
         start_frame = start_frame if start_frame is not None else 0
         end_frame = end_frame if end_frame is not None else self.get_num_frames()

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -8,7 +8,7 @@ from neuroconv.datainterfaces.behavior.movie.movie_utils import (
 )
 from roiextractors import ImagingExtractor
 from neuroconv.utils import FilePathType, ArrayType
-from roiextractors.extraction_tools import NumpyArray
+from roiextractors.extraction_tools import NumpyArray, DtypeType
 
 
 class ScherrerOphysImagingExtractor(ImagingExtractor):
@@ -60,3 +60,6 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
 
     def get_num_channels(self) -> int:
         return self._num_channels
+
+    def get_dtype(self) -> DtypeType:
+        return self.video_capture_context.get_movie_frame_dtype()

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -45,6 +45,27 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
         concatenated_frames = np.concatenate(frames, axis=0).squeeze()
         return concatenated_frames
 
+    def get_video(self, start_frame=None, end_frame=None, channel=0) -> np.ndarray:
+        start_frame = start_frame if start_frame is not None else 0
+        end_frame = end_frame if end_frame is not None else self.get_num_frames()
+
+        video_shape = (end_frame - start_frame,) + self._image_size
+
+        video = np.empty(shape=video_shape, dtype=self.get_dtype())
+        for frame_number in range(end_frame - start_frame):
+            rgb_frame = next(self.video_capture_context)
+
+            # Cast values from uint8 to uint16
+            green_color_data = rgb_frame[..., 1].astype(np.uint16)
+            blue_color_data = rgb_frame[..., 2].astype(np.uint16)
+            # Apply custom conversion to frames : green * 8 + blue / 8
+            gray_frame = (green_color_data * 8) + (blue_color_data / 8)
+            gray_frame = gray_frame.astype(np.uint16)
+
+            video[frame_number] = gray_frame
+
+        return video
+
     def get_image_size(self) -> Tuple:
         return self._image_size
 

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -56,7 +56,7 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
 
         video_shape = (end_frame - start_frame,) + self._image_size
 
-        video = np.empty(shape=video_shape, dtype=self.get_dtype())
+        video = np.empty(shape=video_shape, dtype=np.uint16)
         for frame_number in range(end_frame - start_frame):
             rgb_frame = next(self.video_capture_context)
 

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -19,13 +19,14 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
     def __init__(self, file_path: FilePathType):
         super().__init__()
         self.file_path = file_path
-        self.video_capture_context = VideoCaptureContext(str(self.file_path)).__enter__()
+        self.video_capture_context = VideoCaptureContext(str(self.file_path))
         self._num_channels = 0
         self._channel_names = ["channel_0"]
 
-        self._num_frames = self.video_capture_context.get_movie_frame_count()
-        self._image_size = self.video_capture_context.get_frame_shape()[:-1]
-        self._sampling_frequency = self.video_capture_context.get_movie_fps()
+        with VideoCaptureContext(str(self.file_path)) as vc:
+            self._num_frames = vc.get_movie_frame_count()
+            self._image_size = vc.get_frame_shape()[:-1]
+            self._sampling_frequency = vc.get_movie_fps()
 
     def close(self):
         self.video_capture_context.release()

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -6,13 +6,6 @@ from roiextractors import ImagingExtractor
 from neuroconv.utils import FilePathType, ArrayType
 from roiextractors.extraction_tools import NumpyArray
 
-try:
-    import cv2
-    HAVE_OPENCV = True
-except ImportError:
-    HAVE_OPENCV = False
-INSTALL_MESSAGE = "Please install opencv to use the VideoCaptureContext class! (pip install opencv-python)"
-
 
 def convert_rgb_frame_to_grayscale(rgb_frame: np.ndarray) -> np.ndarray:
     """
@@ -32,8 +25,6 @@ def convert_rgb_frame_to_grayscale(rgb_frame: np.ndarray) -> np.ndarray:
 
 class ScherrerOphysImagingExtractor(ImagingExtractor):
     extractor_name = "ScherrerOphysImaging"
-    installed = HAVE_OPENCV
-    installation_mesg = INSTALL_MESSAGE
 
     def __init__(self, file_path: FilePathType):
         super().__init__()

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -27,6 +27,10 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
         self._image_size = self.video_capture_context.get_frame_shape()[:-1]
         self._sampling_frequency = self.video_capture_context.get_movie_fps()
 
+    def close(self):
+        self.video_capture_context.release()
+        assert self.video_capture_context.isOpened() is False
+
     def get_frames(self, frame_idxs: ArrayType, channel: int = 0) -> NumpyArray:
         frames = []
         for frame_index in frame_idxs:

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -50,13 +50,7 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
             with VideoCaptureContext(str(self.file_path)) as vc:
                 rgb_frame = vc.get_movie_frame(frame_number=frame_index)
 
-            # Cast values from uint8 to uint16
-            green_color_data = rgb_frame[..., 1].astype(np.uint16)
-            blue_color_data = rgb_frame[..., 2].astype(np.uint16)
-            # Apply custom conversion to frames : green * 8 + blue / 8
-            gray_frame = (green_color_data * 8) + (blue_color_data / 8)
-            gray_frame = gray_frame.astype(np.uint16)
-
+            gray_frame = convert_rgb_frame_to_grayscale(rgb_frame)
             frames.append(gray_frame[np.newaxis, ...])
 
         concatenated_frames = np.concatenate(frames, axis=0).squeeze()

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -67,7 +67,7 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
             gray_frame = (green_color_data * 8) + (blue_color_data / 8)
             gray_frame = gray_frame.astype(np.uint16)
 
-            video[frame_number] = gray_frame
+            video[frame_number, ...] = gray_frame
 
         return video
 

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -44,10 +44,6 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
             self._image_size = vc.get_frame_shape()[:-1]
             self._sampling_frequency = vc.get_movie_fps()
 
-    def close(self):
-        self.video_capture_context.release()
-        assert self.video_capture_context.isOpened() is False
-
     def get_frames(self, frame_idxs: ArrayType, channel: int = 0) -> NumpyArray:
         frames = []
         for frame_index in frame_idxs:

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -11,6 +11,22 @@ from neuroconv.utils import FilePathType, ArrayType
 from roiextractors.extraction_tools import NumpyArray
 
 
+def convert_rgb_frame_to_grayscale(rgb_frame: np.ndarray) -> np.ndarray:
+    """
+    Convert an RGB frame to grayscale using the custom conversion of color channels
+    specified by the Fee lab: green * 8 + blue / 8. The data type of the resulting
+    grayscale frame is uint16.
+    """
+    # Cast values from uint8 to uint16
+    green_color_data = rgb_frame[..., 1].astype(np.uint16)
+    blue_color_data = rgb_frame[..., 2].astype(np.uint16)
+    # Apply custom conversion to frames : green * 8 + blue / 8
+    gray_frame = (green_color_data * 8) + (blue_color_data / 8)
+    gray_frame = gray_frame.astype(np.uint16)
+
+    return gray_frame
+
+
 class ScherrerOphysImagingExtractor(ImagingExtractor):
     extractor_name = "ScherrerOphysImaging"
     installed = HAVE_OPENCV
@@ -60,14 +76,7 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
         for frame_number in range(end_frame - start_frame):
             rgb_frame = next(self.video_capture_context)
 
-            # Cast values from uint8 to uint16
-            green_color_data = rgb_frame[..., 1].astype(np.uint16)
-            blue_color_data = rgb_frame[..., 2].astype(np.uint16)
-            # Apply custom conversion to frames : green * 8 + blue / 8
-            gray_frame = (green_color_data * 8) + (blue_color_data / 8)
-            gray_frame = gray_frame.astype(np.uint16)
-
-            video[frame_number, ...] = gray_frame
+            video[frame_number, ...] = convert_rgb_frame_to_grayscale(rgb_frame)
 
         return video
 

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, Optional
 
 import numpy as np
 from neuroconv.datainterfaces.behavior.movie.movie_utils import (
@@ -56,7 +56,12 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
         concatenated_frames = np.concatenate(frames, axis=0).squeeze()
         return concatenated_frames
 
-    def get_video(self, start_frame=None, end_frame=None, channel=0) -> np.ndarray:
+    def get_video(
+            self,
+            start_frame: Optional[int] = None,
+            end_frame: Optional[int] = None,
+            channel: Optional[int] = 0
+    ) -> np.ndarray:
         start_frame = start_frame if start_frame is not None else 0
         end_frame = end_frame if end_frame is not None else self.get_num_frames()
 

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -53,7 +53,7 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
             gray_frame = convert_rgb_frame_to_grayscale(rgb_frame)
             frames.append(gray_frame[np.newaxis, ...])
 
-        concatenated_frames = np.concatenate(frames, axis=0).squeeze()
+        concatenated_frames = np.concatenate(frames, axis=0)
         return concatenated_frames
 
     def get_video(
@@ -65,13 +65,16 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
         start_frame = start_frame if start_frame is not None else 0
         end_frame = end_frame if end_frame is not None else self.get_num_frames()
 
+        # Set video current frame to start_frame
+        self.video_capture_context.current_frame = start_frame
+
         video_shape = (end_frame - start_frame,) + self._image_size
 
         video = np.empty(shape=video_shape, dtype=np.uint16)
-        for frame_number in range(end_frame - start_frame):
-            rgb_frame = next(self.video_capture_context)
-
+        for frame_number, rgb_frame in enumerate(self.video_capture_context):
             video[frame_number, ...] = convert_rgb_frame_to_grayscale(rgb_frame)
+            if self.video_capture_context.current_frame == end_frame:
+                return video
 
         return video
 

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -8,7 +8,7 @@ from neuroconv.datainterfaces.behavior.movie.movie_utils import (
 )
 from roiextractors import ImagingExtractor
 from neuroconv.utils import FilePathType, ArrayType
-from roiextractors.extraction_tools import NumpyArray, DtypeType
+from roiextractors.extraction_tools import NumpyArray
 
 
 class ScherrerOphysImagingExtractor(ImagingExtractor):
@@ -35,7 +35,7 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
     def get_frames(self, frame_idxs: ArrayType, channel: int = 0) -> NumpyArray:
         frames = []
         for frame_index in frame_idxs:
-            with self.video_capture_context as vc:
+            with VideoCaptureContext(str(self.file_path)) as vc:
                 rgb_frame = vc.get_movie_frame(frame_number=frame_index)
 
             # Cast values from uint8 to uint16
@@ -85,6 +85,3 @@ class ScherrerOphysImagingExtractor(ImagingExtractor):
 
     def get_num_channels(self) -> int:
         return self._num_channels
-
-    def get_dtype(self) -> DtypeType:
-        return self.video_capture_context.get_movie_frame_dtype()

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimagingextractor.py
@@ -1,14 +1,17 @@
 from typing import Tuple, Optional
 
 import numpy as np
-from neuroconv.datainterfaces.behavior.movie.movie_utils import (
-    VideoCaptureContext,
-    HAVE_OPENCV,
-    INSTALL_MESSAGE,
-)
+from neuroconv.datainterfaces.behavior.movie.movie_utils import VideoCaptureContext
 from roiextractors import ImagingExtractor
 from neuroconv.utils import FilePathType, ArrayType
 from roiextractors.extraction_tools import NumpyArray
+
+try:
+    import cv2
+    HAVE_OPENCV = True
+except ImportError:
+    HAVE_OPENCV = False
+INSTALL_MESSAGE = "Please install opencv to use the VideoCaptureContext class! (pip install opencv-python)"
 
 
 def convert_rgb_frame_to_grayscale(rgb_frame: np.ndarray) -> np.ndarray:

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimaginginterface.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimaginginterface.py
@@ -4,14 +4,12 @@ from neuroconv.datainterfaces.ophys.baseimagingextractorinterface import (
 from neuroconv.utils import calculate_regular_series_rate
 from roiextractors.multiimagingextractor import MultiImagingExtractor
 
-from fee_lab_to_nwb.scherrer_ophys.scherrerophysimagingextractor import (
-    ScherrerOphysImagingExtractor,
-)
-from fee_lab_to_nwb.scherrer_ophys.utils import get_timestamps_from_csv
+from ..scherrer_ophys.utils import get_timestamps_from_csv
+from .scherrerophysimagingextractor import ScherrerOphysImagingExtractor
 
 
-class ScherrerOphysImagingExtractorInterface(BaseImagingExtractorInterface):
-    IX = MultiImagingExtractor
+class ScherrerOphysImagingInterface(BaseImagingExtractorInterface):
+    Extractor = MultiImagingExtractor
 
     def __init__(
         self, ophys_file_paths: list, timestamps_file_path: str, verbose: bool = True

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimaginginterface.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimaginginterface.py
@@ -16,7 +16,7 @@ class ScherrerOphysImagingInterface(BaseImagingExtractorInterface):
     ):
         imaging_extractors = [
             ScherrerOphysImagingExtractor(file_path=file_path)
-            for file_path in ophys_file_paths
+            for file_path in sorted(ophys_file_paths)
         ]
         super().__init__(imaging_extractors=imaging_extractors)
         timestamps = get_timestamps_from_csv(file_path=timestamps_file_path)

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysnwbconverter.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysnwbconverter.py
@@ -1,11 +1,9 @@
 """Primary NWBConverter class for this dataset."""
-from neuroconv import (
-    NWBConverter,
-    MovieInterface,
-)
+from neuroconv import NWBConverter
+from neuroconv.datainterfaces import MovieInterface
 
-from fee_lab_to_nwb.scherrer_ophys.scherrerophysimagingextractorinterface import (
-    ScherrerOphysImagingExtractorInterface,
+from fee_lab_to_nwb.scherrer_ophys.scherrerophysimaginginterface import (
+    ScherrerOphysImagingInterface,
 )
 
 
@@ -14,5 +12,5 @@ class ScherrerOphysNWBConverter(NWBConverter):
 
     data_interface_classes = dict(
         Movie=MovieInterface,
-        Ophys=ScherrerOphysImagingExtractorInterface,
+        Ophys=ScherrerOphysImagingInterface,
     )


### PR DESCRIPTION
Add support for `get_video` in `ScherrerOphysImagingExtractor`. 
This should be merged after https://github.com/catalystneuro/roiextractors/pull/195.