### PR TITLE
Create a hierarchical table for syllables and motifs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 ### Features
 * The `ScherrerOphysSegmentationInterface` is modified to write the configurations
   from EXTRACT segmentation to the NWB File. [PR #42](https://github.com/catalystneuro/fee-lab-to-nwb/pull/42)
+* The `MotifInterface` is modified to add the timings of syllables along with the motifs.
+  The motifs are added to the trials table and is a `HierarchicalBehavioralTable` where the
+  lowest hierarchical level is the level of syllables. [PR #34](https://github.com/catalystneuro/fee-lab-to-nwb/pull/34)
 
 ### Testing
 * Added auto-detector workflow for CHANGELOG.md updates. [PR #41](https://github.com/catalystneuro/fee-lab-to-nwb/pull/41)

--- a/src/fee_lab_to_nwb/happ_ecephys/happ_ecephys_requirements.txt
+++ b/src/fee_lab_to_nwb/happ_ecephys/happ_ecephys_requirements.txt
@@ -1,1 +1,2 @@
 ndx-sound
+ndx-hierarchical-behavioral-data==0.1.1

--- a/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
+++ b/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
@@ -66,13 +66,13 @@ class MotifInterface(BaseDataInterface):
 
         return timestamps
 
-    def get_syllables_from_motif_timetamps(self, motif_timestamps: np.ndarray):
+    def get_syllables_from_motif_timetamps(self, motif_timestamps: np.ndarray) -> TimeIntervals:
         """Returns the timings of syllables using the onset times of the motifs."""
-        syllables = TimeIntervals(name="Syllables", description="The timings of syllables.")
-        syllables.add_column("label", "The label of syllable.")
+        syllables_table = TimeIntervals(name="Syllables", description="The timings of syllables.")
+        syllables_table.add_column("label", "The label of syllable.")
         syllable_start_times, syllable_end_times, syllable_names = [], [], []
         motif_syllable_mapping = self.motif_syllable_mapping
-        for motif_name, motif_start_time in zip(self.motifs[:, 0], motif_timestamps):
+        for motif_name, motif_start_time in zip(self.motif_names, motif_timestamps):
             if len(self.motif_syllable_mapping["Song number"].value_counts()) > 1:
                 motif_syllable_mapping = self.motif_syllable_mapping.loc[
                     self.motif_syllable_mapping["Motif name"] == motif_name
@@ -90,13 +90,13 @@ class MotifInterface(BaseDataInterface):
         for (syllable_name, (start_time, end_time)) in zip(
             syllable_names, zip(syllable_start_times, syllable_end_times)
         ):
-            syllables.add_interval(
+            syllables_table.add_interval(
                 label=syllable_name,
                 start_time=start_time,
                 stop_time=end_time,
             )
 
-        return syllables
+        return syllables_table
 
     def create_hierarchical_table_from_syllables(self, syllables: TimeIntervals):
         """Create a hierarchical table from the timings of motifs.

--- a/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
+++ b/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
@@ -68,7 +68,7 @@ class MotifInterface(BaseDataInterface):
         of each syllable is fixed for now, but should be modified in the future given
         more information about the mapping between motifs and syllables."""
         syllables = TimeIntervals(name="Syllables", description="desc")
-        syllables.add_column('label', 'The label of syllable.')
+        syllables.add_column("label", "The label of syllable.")
 
         syllables_start_times, syllables_end_times = [], []
         motif_start_times = list(motif_timestamps[::1])
@@ -78,11 +78,11 @@ class MotifInterface(BaseDataInterface):
             # Construct the timings of syllables from motif timestamps,
             # assuming that the number of syllables within motifs are ALWAYS the same.
             syllable_onset_times = np.linspace(
-                    start=start_time,
-                    stop=end_time,
-                    num=self.num_syllables_per_motif,
-                    endpoint=False,
-                )
+                start=start_time,
+                stop=end_time,
+                num=self.num_syllables_per_motif,
+                endpoint=False,
+            )
             syllables_start_times.extend(syllable_onset_times)
             # Until we can reverse-engineer the latency of each syllable from the mapping
             syllables_latency = np.nanmedian(np.diff(syllable_onset_times))
@@ -92,8 +92,7 @@ class MotifInterface(BaseDataInterface):
         syllables_labels = ["a", "b", "c", "d", "e"] * len(motif_timestamps)
 
         for (syllable_label, (start_time, end_time)) in zip(
-                syllables_labels,
-                zip(syllables_start_times, syllables_end_times)
+            syllables_labels, zip(syllables_start_times, syllables_end_times)
         ):
             syllables.add_interval(
                 label=syllable_label,
@@ -106,7 +105,7 @@ class MotifInterface(BaseDataInterface):
             description="The timings of motifs.",
             lower_tier_table=syllables,
         )
-        motifs_table.add_column('motif_name', 'The name of motif.')
+        motifs_table.add_column("motif_name", "The name of motif.")
 
         for motif_ind, motif_label in enumerate(self.motifs[:, 0]):
             motifs_table.add_interval(
@@ -126,9 +125,7 @@ class MotifInterface(BaseDataInterface):
         # Synchronize the timestamps of motifs with the SpikeGLX timestamps
         motif_timestamps = self.get_synchronized_motif_timestamps()
         # Create a hierarchical table with syllables and motif timestamps
-        motifs_table = self.create_hierarchical_table_from_motif_timestamps(
-            motif_timestamps=motif_timestamps
-        )
+        motifs_table = self.create_hierarchical_table_from_motif_timestamps(motif_timestamps=motif_timestamps)
 
         # Create behavioral processing module
         behavior_module = nwbfile.create_processing_module(

--- a/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
+++ b/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
@@ -36,9 +36,10 @@ class MotifInterface(BaseDataInterface):
         self.motifs = self.read_motif_timing_data()
         self.motif_syllable_mapping = pd.DataFrame.from_dict(motif_syllable_mapping)
 
-    def read_motif_data(self):
+    def read_motif_timing_data(self):
         """Reads the .mat file containing the timing of the motifs.
         Returns the identifier and timing of the motifs."""
+        # todo: add syll_phase_timingData
         motif_data = loadmat(self.source_data["file_path"], squeeze_me=True, mat_dtype=True)
         assert "motifTimingData" in motif_data, "'motifTimingData' should be in file."
 

--- a/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
+++ b/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
@@ -83,13 +83,23 @@ class MotifInterface(BaseDataInterface):
                 syllable_names.append(syllable["Syllable"])
                 syllable_start_time = syllable_end_time + syllable["Subsequent Silence (sec)"]
 
-        return syllable_start_times, syllable_end_times, syllable_names
+        # Create the TimeIntervals for syllables
+        for (syllable_name, (start_time, end_time)) in zip(
+            syllable_names, zip(syllable_start_times, syllable_end_times)
+        ):
+            syllables.add_interval(
+                label=syllable_name,
+                start_time=start_time,
+                stop_time=end_time,
+            )
+
+        return syllables
 
     def create_hierarchical_table_from_syllables(self, syllables: TimeIntervals):
         """Create a hierarchical table from the timings of motifs.
         The lowest hierarchical level is the level of syllables."""
         motifs_table = HierarchicalBehavioralTable(
-            name="Motifs",
+            name="trials",
             description="The timings of motifs.",
             lower_tier_table=syllables,
         )
@@ -121,24 +131,14 @@ class MotifInterface(BaseDataInterface):
         # Synchronize the timestamps of motifs with the SpikeGLX timestamps
         motif_timestamps = self.get_synchronized_motif_timestamps()
 
-        # Get syllable timings
-        syllable_start_times, syllable_end_times, syllable_names = self.get_syllables_from_motif_timetamps(
-            motif_timestamps=motif_timestamps
-        )
-
-        # Add syllables as trials
-        for start_time, stop_time in zip(syllable_start_times, syllable_end_times):
-            nwbfile.add_trial(start_time=start_time, stop_time=stop_time)
-
-        nwbfile.add_trial_column(
-            name="syllable_name",
-            description="Identifier of the syllable.",
-            data=list(syllable_names),
-        )
+        # The TimeIntervals for syllables
+        syllables = self.get_syllables_from_motif_timetamps(motif_timestamps=motif_timestamps)
 
         # Create a hierarchical table with syllables and motif timestamps
         motifs_table = self.create_hierarchical_table_from_syllables(
-            syllables=nwbfile.trials,
+            syllables=syllables,
         )
-        # Add motifs as time intervals
-        nwbfile.add_time_intervals(motifs_table)
+        # Set the trials table to motifs
+        nwbfile.trials = motifs_table
+        # Add the syllables to the NWBFile
+        nwbfile.add_time_intervals(syllables)

--- a/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
+++ b/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
@@ -52,13 +52,8 @@ class MotifInterface(BaseDataInterface):
         """Reads the .mat file containing the timing of the motifs."""
         return loadmat(self.source_data["file_path"], squeeze_me=True, mat_dtype=True)
 
-        motifs = motif_data["motifTimingData"]
-        return motifs
-
-    def get_synchronized_motif_timestamps(self):
+    def synchronize_timestamps(self, timestamps: np.ndarray) -> np.ndarray:
         """Synchronizes the timings of motifs with the SpikeGLX timestamps."""
-        motif_timestamps = self.motifs[:, 1]
-
         sync_data = loadmat(self.sync_file_path, squeeze_me=True, mat_dtype=True)
         assert "Audio_eventTimes" in sync_data, f"'Audio_eventTimes' should be in file."
         assert "IMEC_eventTimes" in sync_data, f"'IMEC_eventTimes' should be in file."
@@ -66,10 +61,10 @@ class MotifInterface(BaseDataInterface):
         audio_timestamps = sync_data["Audio_eventTimes"][0]
         imec_timestamps = sync_data["IMEC_eventTimes"][0]
 
-        indices = np.searchsorted(audio_timestamps, motif_timestamps)
-        motif_timestamps += imec_timestamps[indices] - audio_timestamps[indices]
+        indices = np.searchsorted(audio_timestamps, timestamps)
+        timestamps += imec_timestamps[indices] - audio_timestamps[indices]
 
-        return motif_timestamps
+        return timestamps
 
     def get_syllables_from_motif_timetamps(self, motif_timestamps: np.ndarray):
         """Returns the timings of syllables using the onset times of the motifs."""

--- a/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
+++ b/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
@@ -84,27 +84,29 @@ class MotifInterface(BaseDataInterface):
 
         return syllable_start_times, syllable_end_times, syllable_names
 
-        for (syllable_label, (start_time, end_time)) in zip(
-            syllables_labels, zip(syllables_start_times, syllables_end_times)
-        ):
-            syllables.add_interval(
-                label=syllable_label,
-                start_time=start_time,
-                stop_time=end_time,
-            )
-
+    def create_hierarchical_table_from_syllables(self, syllables: TimeIntervals):
+        """Create a hierarchical table from the timings of motifs.
+        The lowest hierarchical level is the level of syllables."""
         motifs_table = HierarchicalBehavioralTable(
             name="Motifs",
             description="The timings of motifs.",
             lower_tier_table=syllables,
         )
-        motifs_table.add_column("motif_name", "The name of motif.")
 
-        for motif_ind, motif_label in enumerate(self.motifs[:, 0]):
+        syllable_names = self.motif_syllable_mapping["Syllable"].values
+        for motif_ind, motif_name in enumerate(self.motifs[:, 0]):
+            if len(self.motif_syllable_mapping["Song number"].value_counts()) > 1:
+                motif_syllable_mapping = self.motif_syllable_mapping.loc[
+                    self.motif_syllable_mapping["Motif name"] == motif_name
+                ]
+                syllable_names = motif_syllable_mapping["Syllable"].values
+
+            start = len(syllable_names) * motif_ind
+            stop = len(syllable_names) + start
+            next_tier = list(np.arange(start=start, stop=stop))
             motifs_table.add_interval(
-                motif_name=motif_label.split("_")[1],
-                label=motif_label,
-                next_tier=np.arange(0, self.num_syllables_per_motif) + (self.num_syllables_per_motif * motif_ind),
+                label=motif_name,
+                next_tier=next_tier,
             )
 
         return motifs_table

--- a/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
+++ b/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
@@ -12,7 +12,12 @@ from scipy.io import loadmat
 class MotifInterface(BaseDataInterface):
     """Data interface for adding timing of the motifs as trials to the NWB file."""
 
-    def __init__(self, file_path: str, sync_file_path: str, num_syllables_per_motif: int = 5):
+    def __init__(
+        self,
+        file_path: str,
+        sync_file_path: str,
+        motif_syllable_mapping: dict,
+    ):
         """
         Create the interface for writing the timing of the motifs to the NWB file.
         The motifs are added as trials.
@@ -23,11 +28,13 @@ class MotifInterface(BaseDataInterface):
             The path to the file containing the timing of the motifs.
         sync_file_path: str
             The path to the file containing the Audio and SpikeGLX timestamps for synchronization.
+        motif_syllable_mapping: dict
+            The dictionary that contains the duration of syllables and to which motif they belong.
         """
         super().__init__(file_path=file_path)
         self.sync_file_path = sync_file_path
-        self.motifs = self.read_motif_data()
-        self.num_syllables_per_motif = num_syllables_per_motif
+        self.motifs = self.read_motif_timing_data()
+        self.motif_syllable_mapping = pd.DataFrame.from_dict(motif_syllable_mapping)
 
     def read_motif_data(self):
         """Reads the .mat file containing the timing of the motifs.

--- a/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
+++ b/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
@@ -34,15 +34,23 @@ class MotifInterface(BaseDataInterface):
         """
         super().__init__(file_path=file_path)
         self.sync_file_path = sync_file_path
-        self.motifs = self.read_motif_timing_data()
+        motifs = self.read_motif_timing_data()
+        motif_struct_name = "motifTimingData"
+        assert motif_struct_name in motifs, f"'{motif_struct_name}' should be in file."
+        self.motif_names = motifs[motif_struct_name][:, 0]
+        self.motif_timestamps = motifs[motif_struct_name][:, 1]
+        # The syllables experiment has a separate column for syllables timings
+        syllable_struct_name = "syll_phase_timingData"
+        self.syllable_names = None
+        self.syllable_timestamps = None
+        if syllable_struct_name in motifs:
+            self.syllable_names = motifs[syllable_struct_name][:, 0]
+            self.syllable_timestamps = motifs[syllable_struct_name][:, 1]
         self.motif_syllable_mapping = pd.DataFrame.from_dict(motif_syllable_mapping)
 
     def read_motif_timing_data(self):
-        """Reads the .mat file containing the timing of the motifs.
-        Returns the identifier and timing of the motifs."""
-        # todo: add syll_phase_timingData
-        motif_data = loadmat(self.source_data["file_path"], squeeze_me=True, mat_dtype=True)
-        assert "motifTimingData" in motif_data, "'motifTimingData' should be in file."
+        """Reads the .mat file containing the timing of the motifs."""
+        return loadmat(self.source_data["file_path"], squeeze_me=True, mat_dtype=True)
 
         motifs = motif_data["motifTimingData"]
         return motifs

--- a/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
+++ b/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
@@ -108,7 +108,7 @@ class MotifInterface(BaseDataInterface):
         )
 
         syllable_names = self.motif_syllable_mapping["Syllable"].values
-        for motif_ind, motif_name in enumerate(self.motifs[:, 0]):
+        for motif_ind, motif_name in enumerate(self.motif_names):
             if len(self.motif_syllable_mapping["Song number"].value_counts()) > 1:
                 motif_syllable_mapping = self.motif_syllable_mapping.loc[
                     self.motif_syllable_mapping["Motif name"] == motif_name
@@ -132,10 +132,10 @@ class MotifInterface(BaseDataInterface):
     ):
 
         # Synchronize the timestamps of motifs with the SpikeGLX timestamps
-        motif_timestamps = self.get_synchronized_motif_timestamps()
+        motif_timestamps = self.synchronize_timestamps(timestamps=self.motif_timestamps)
 
         # The TimeIntervals for syllables
-        syllables = self.get_syllables_from_motif_timetamps(motif_timestamps=motif_timestamps)
+        syllables_table = self.get_syllables_from_motif_timetamps(motif_timestamps=motif_timestamps)
 
         # Create a hierarchical table with syllables and motif timestamps
         motifs_table = self.create_hierarchical_table_from_syllables(
@@ -144,4 +144,4 @@ class MotifInterface(BaseDataInterface):
         # Set the trials table to motifs
         nwbfile.trials = motifs_table
         # Add the syllables to the NWBFile
-        nwbfile.add_time_intervals(syllables)
+        nwbfile.add_time_intervals(syllables_table)

--- a/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
+++ b/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
@@ -59,7 +59,7 @@ class MotifInterface(BaseDataInterface):
         imec_timestamps = sync_data["IMEC_eventTimes"][0]
 
         indices = np.searchsorted(audio_timestamps, motif_timestamps)
-        motif_timestamps += (imec_timestamps[indices] - audio_timestamps[indices])
+        motif_timestamps += imec_timestamps[indices] - audio_timestamps[indices]
 
         return motif_timestamps
 

--- a/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
+++ b/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
@@ -1,15 +1,18 @@
 from typing import Optional
 
 import numpy as np
+from ndx_hierarchical_behavioral_data import HierarchicalBehavioralTable
 from neuroconv.basedatainterface import BaseDataInterface
+from neuroconv.utils import ArrayType
 from pynwb import NWBFile
+from pynwb.epoch import TimeIntervals
 from scipy.io import loadmat
 
 
 class MotifInterface(BaseDataInterface):
     """Data interface for adding timing of the motifs as trials to the NWB file."""
 
-    def __init__(self, file_path: str, sync_file_path: str):
+    def __init__(self, file_path: str, sync_file_path: str, num_syllables_per_motif: int = 5):
         """
         Create the interface for writing the timing of the motifs to the NWB file.
         The motifs are added as trials.
@@ -24,6 +27,7 @@ class MotifInterface(BaseDataInterface):
         super().__init__(file_path=file_path)
         self.sync_file_path = sync_file_path
         self.motifs = self.read_motif_data()
+        self.num_syllables_per_motif = num_syllables_per_motif
 
     def read_motif_data(self):
         """Reads the .mat file containing the timing of the motifs.
@@ -57,23 +61,78 @@ class MotifInterface(BaseDataInterface):
 
         return motif_timestamps
 
+    def create_hierarchical_table_from_motif_timestamps(self, motif_timestamps: ArrayType):
+        """Create a hierarchical table from the timings of motifs.
+        The lowest hierarchical level is the level of syllables. The number of
+        syllables within a motif is assumed to be fixed per experiment. The latency
+        of each syllable is fixed for now, but should be modified in the future given
+        more information about the mapping between motifs and syllables."""
+        syllables = TimeIntervals(name="Syllables", description="desc")
+        syllables.add_column('label', 'The label of syllable.')
+
+        syllables_start_times, syllables_end_times = [], []
+        motif_start_times = list(motif_timestamps[::1])
+        motif_end_times = list(motif_timestamps[1::])
+        motif_end_times.append(np.nan)  # the last num_syllables_per_motif will be nan
+        for (start_time, end_time) in zip(motif_start_times, motif_end_times):
+            # Construct the timings of syllables from motif timestamps,
+            # assuming that the number of syllables within motifs are ALWAYS the same.
+            syllable_onset_times = np.linspace(
+                    start=start_time,
+                    stop=end_time,
+                    num=self.num_syllables_per_motif,
+                    endpoint=False,
+                )
+            syllables_start_times.extend(syllable_onset_times)
+            # Until we can reverse-engineer the latency of each syllable from the mapping
+            syllables_latency = np.nanmedian(np.diff(syllable_onset_times))
+            syllables_end_times.extend(syllable_onset_times + syllables_latency)
+
+        # Until we lack the mapping between motifs and syllables we assume these labels
+        syllables_labels = ["a", "b", "c", "d", "e"] * len(motif_timestamps)
+
+        for (syllable_label, (start_time, end_time)) in zip(
+                syllables_labels,
+                zip(syllables_start_times, syllables_end_times)
+        ):
+            syllables.add_interval(
+                label=syllable_label,
+                start_time=start_time,
+                stop_time=end_time,
+            )
+
+        motifs_table = HierarchicalBehavioralTable(
+            name="Motifs",
+            description="The timings of motifs.",
+            lower_tier_table=syllables,
+        )
+        motifs_table.add_column('motif_name', 'The name of motif.')
+
+        for motif_ind, motif_label in enumerate(self.motifs[:, 0]):
+            motifs_table.add_interval(
+                motif_name=motif_label.split("_")[1],
+                label=motif_label,
+                next_tier=np.arange(0, self.num_syllables_per_motif) + (self.num_syllables_per_motif * motif_ind),
+            )
+
+        return motifs_table
+
     def run_conversion(
         self,
         nwbfile: NWBFile,
         metadata: Optional[dict] = None,
     ):
 
+        # Synchronize the timestamps of motifs with the SpikeGLX timestamps
         motif_timestamps = self.get_synchronized_motif_timestamps()
-        motif_ids = self.motifs[:, 0]
-
-        # Motif timestamps only denote the onset of the stimuli
-        for (start_time, stop_time) in zip(motif_timestamps[::1], motif_timestamps[1::]):
-            nwbfile.add_trial(start_time=start_time, stop_time=stop_time)
-        # The last motif does not have a stop time
-        nwbfile.add_trial(start_time=motif_timestamps[-1], stop_time=np.nan)
-
-        nwbfile.add_trial_column(
-            name="motif_id",
-            description="Identifier of the repeating audio stimulus.",
-            data=motif_ids,
+        # Create a hierarchical table with syllables and motif timestamps
+        motifs_table = self.create_hierarchical_table_from_motif_timestamps(
+            motif_timestamps=motif_timestamps
         )
+
+        # Create behavioral processing module
+        behavior_module = nwbfile.create_processing_module(
+            name="behavior", description="The auditory stimulus of syllables and motifs."
+        )
+        # Add the hierarchical table to the processing module
+        behavior_module.add(motifs_table)

--- a/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
+++ b/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
@@ -98,7 +98,7 @@ class MotifInterface(BaseDataInterface):
 
         return syllables_table
 
-    def create_hierarchical_table_from_syllables(self, syllables: TimeIntervals):
+    def create_hierarchical_table_from_syllables(self, syllables: TimeIntervals) -> HierarchicalBehavioralTable:
         """Create a hierarchical table from the timings of motifs.
         The lowest hierarchical level is the level of syllables."""
         motifs_table = HierarchicalBehavioralTable(

--- a/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
+++ b/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
@@ -1,9 +1,10 @@
 from typing import Optional
 
 import numpy as np
+import pandas as pd
+
 from ndx_hierarchical_behavioral_data import HierarchicalBehavioralTable
 from neuroconv.basedatainterface import BaseDataInterface
-from neuroconv.utils import ArrayType
 from pynwb import NWBFile
 from pynwb.epoch import TimeIntervals
 from scipy.io import loadmat

--- a/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
+++ b/src/fee_lab_to_nwb/happ_ecephys/happmotifinterface.py
@@ -136,11 +136,8 @@ class MotifInterface(BaseDataInterface):
         )
 
         # Create a hierarchical table with syllables and motif timestamps
-        motifs_table = self.create_hierarchical_table_from_motif_timestamps(motif_timestamps=motif_timestamps)
-
-        # Create behavioral processing module
-        behavior_module = nwbfile.create_processing_module(
-            name="behavior", description="The auditory stimulus of syllables and motifs."
+        motifs_table = self.create_hierarchical_table_from_syllables(
+            syllables=nwbfile.trials,
         )
-        # Add the hierarchical table to the processing module
-        behavior_module.add(motifs_table)
+        # Add motifs as time intervals
+        nwbfile.add_time_intervals(motifs_table)


### PR DESCRIPTION
The `MotifInterface` is modified to add the timings of syllables along with the motifs.
The motifs are added to the trials table and is a `HierarchicalBehavioralTable` where the
lowest hierarchical level is the level of syllables. The syllables are added to the file as `TimeIntervals` object.