### PR TITLE
Showcasing auto-changelog 

### DIFF
--- a/.auto-changelog
+++ b/.auto-changelog
@@ -1,0 +1,5 @@
+{
+  "template": "changelog_template.hbs",
+  "unreleased": true,
+  "ignoreCommitPattern": ".pre-commit."
+}

--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -1,0 +1,18 @@
+name: Auto generate CHANGELOG.md
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  if_merged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - name: Install auto-changelog
+        run: |
+          npm install -g auto-changelog
+          auto-changelog && git add CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,31 @@
-# Upcoming
 
-### Improvements
-* Create file for tracking changes. [PR #36](https://github.com/catalystneuro/fee-lab-to-nwb/pull/36)
+# Unreleased
+
+* add CHANGELOG.md. [PR#36](https://github.com/catalystneuro/fee-lab-to-nwb/pull/36)
+* Create PULL_REQUEST_TEMPLATE.md [`0d26f9d`](https://github.com/catalystneuro/fee-lab-to-nwb/commit/0d26f9d44087c755f0a42b9018e45e36c915cef2)
+* add first entry to upcoming changes [`a13ce52`](https://github.com/catalystneuro/fee-lab-to-nwb/commit/a13ce52d67116ad7c59d6fc1294e317c67e1e604)
 
 # v1.0.0
 
-* The first release of fee-lab-to-nwb. [PR #31](https://github.com/catalystneuro/fee-lab-to-nwb/pull/31)
+* Release first version. [PR#31](https://github.com/catalystneuro/fee-lab-to-nwb/pull/31)
+* Add custom segmentation interface with timestamps. [PR#28](https://github.com/catalystneuro/fee-lab-to-nwb/pull/28)
+* Add `ecephys` pipeline. [PR#21](https://github.com/catalystneuro/fee-lab-to-nwb/pull/21)
+* Update `README.md` with project structure. [PR#30](https://github.com/catalystneuro/fee-lab-to-nwb/pull/30)
+* Fix import `fee_lab_to_nwb`. [PR#27](https://github.com/catalystneuro/fee-lab-to-nwb/pull/27)
+* Add `get_video` to ScherrerOphysImagingExtractor. [PR#19](https://github.com/catalystneuro/fee-lab-to-nwb/pull/19)
+* Add MotifInterface. [PR#24](https://github.com/catalystneuro/fee-lab-to-nwb/pull/24)
+* Integrate audiointerface into ecephys pipeline. [PR#25](https://github.com/catalystneuro/fee-lab-to-nwb/pull/25)
+* Add custom data interface for audio. [PR#20](https://github.com/catalystneuro/fee-lab-to-nwb/pull/20)
+* Change imports to `neuroconv`. [PR#18](https://github.com/catalystneuro/fee-lab-to-nwb/pull/18)
+* Fix image shape mismatch in `ScherrerOphysImagingExtractor`. [PR#17](https://github.com/catalystneuro/fee-lab-to-nwb/pull/17)
+* Convert imaging data. [PR#14](https://github.com/catalystneuro/fee-lab-to-nwb/pull/14)
+* Add custom ImagingExtractor for ophys data. [PR#11](https://github.com/catalystneuro/fee-lab-to-nwb/pull/11)
+* Fill NWB metadata. [PR#12](https://github.com/catalystneuro/fee-lab-to-nwb/pull/12)
+* Testing pre-commit. [PR#10](https://github.com/catalystneuro/fee-lab-to-nwb/pull/10)
+* Fill metadata. [PR#9](https://github.com/catalystneuro/fee-lab-to-nwb/pull/9)
+* Make package pip installable. [PR#8](https://github.com/catalystneuro/fee-lab-to-nwb/pull/8)
+* Process behavioral data . [PR#7](https://github.com/catalystneuro/fee-lab-to-nwb/pull/7)
+* Setup folder structure for ophys conversion. [PR#4](https://github.com/catalystneuro/fee-lab-to-nwb/pull/4)
+* Initial commit [`ab22580`](https://github.com/catalystneuro/fee-lab-to-nwb/commit/ab22580bedd758de70dd4fac673e4de396a18005)
+* add single video imagingextractor [`94871d1`](https://github.com/catalystneuro/fee-lab-to-nwb/commit/94871d10ba8d59a1b28ba2f26587473488a1c461)
+* update README.md [`797d8d8`](https://github.com/catalystneuro/fee-lab-to-nwb/commit/797d8d819ea92f6362e64e340564e0da84de3637)

--- a/changelog_template.hbs
+++ b/changelog_template.hbs
@@ -1,0 +1,12 @@
+
+{{#each releases}}
+  # {{title}}
+
+  {{#each merges}}
+    * {{message}}. [PR#{{id}}]({{href}})
+  {{/each}}
+  {{#each commits}}
+    * {{#if breaking}}**Breaking change:** {{/if}}{{subject}}{{#if href}} [`{{shorthash}}`]({{href}}){{/if}}
+  {{/each}}
+
+{{/each}}


### PR DESCRIPTION
This PR is only meant to showcase [auto-changelog](https://github.com/cookpete/auto-changelog#what-you-might-do-if-youre-clever) capabilities for automating `CHANGELOG.md`.

_overall_: works great locally (see generated `CHANGELOG.md`), but how to use it from github actions?

**PROS**:
- customizable (can use custom template and config, can exclude CI commits, can include unreleased changes)
- works without having to use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) (for reference: https://github.com/marketplace/actions/auto-changelog only works with conventional commits)

**CONS**:
- only updates after a PR has been merged (tried to put together a prototype github action for that)

## Checklist

- [ ] Update `CHANGELOG.md`
