### PR TITLE
Adjust timestamps for behavior video

### DIFF
--- a/src/fee_lab_to_nwb/scherrer_ophys/convert_session.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/convert_session.py
@@ -56,7 +56,8 @@ ophys_times = get_timestamps_from_csv(file_path=ophys_timestamp_file_path)
 behavior_times = get_timestamps_from_csv(file_path=behavior_data_file_path)
 # The timings of optical imaging are missing timezone information, therefore
 # we are adding the timezone information to the first time to get the offset
-offset = behavior_times[0] - ophys_times[0].replace(tzinfo=ZoneInfo("US/Eastern"))
+tzinfo = behavior_times[0].tz if behavior_times[0].tz is not None else ZoneInfo("US/Eastern")
+offset = behavior_times[0] - ophys_times[0].replace(tzinfo=tzinfo)
 offset_in_seconds = offset.total_seconds()
 unadjusted_timestamps = shift_timestamps_to_start_from_zero(timestamps=behavior_times)
 adjusted_timestamps = list(unadjusted_timestamps + offset_in_seconds)
@@ -71,7 +72,7 @@ metadata = ophys_dataset_converter.get_metadata()
 metadata = dict_deep_update(metadata, metadata_from_yaml)
 
 session_start_time = datetime.strptime(ophys_dataset_timestamp, "%Y-%m-%dT%H_%M_%S")
-session_start_time = session_start_time.replace(tzinfo=ZoneInfo("US/Eastern"))
+session_start_time = session_start_time.replace(tzinfo=tzinfo)
 
 metadata["NWBFile"].update(
     session_start_time=str(session_start_time),

--- a/src/fee_lab_to_nwb/scherrer_ophys/convert_session.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/convert_session.py
@@ -52,9 +52,15 @@ source_data = dict(
     ),
 )
 
-timestamps = get_timestamps_from_csv(file_path=behavior_data_file_path)
+unadjusted_timestamps = get_timestamps_from_csv(file_path=behavior_data_file_path)
+ophys_timestamps = get_timestamps_from_csv(file_path=ophys_timestamp_file_path, adjust_to_zero=False)
+behavior_timestamps = get_timestamps_from_csv(file_path=behavior_data_file_path, adjust_to_zero=False)
+offset = behavior_timestamps[0].replace(tzinfo=None) - ophys_timestamps[0]
+offset_in_seconds = offset.total_seconds()
+adjusted_timestamps = [timestamp + offset_in_seconds for timestamp in unadjusted_timestamps]
+
 conversion_options = dict(
-    Movie=dict(external_mode=True, timestamps=timestamps),
+    Movie=dict(external_mode=True, timestamps=adjusted_timestamps),
 )
 
 ophys_dataset_converter = ScherrerOphysNWBConverter(source_data=source_data)

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimaginginterface.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimaginginterface.py
@@ -4,8 +4,7 @@ from neuroconv.datainterfaces.ophys.baseimagingextractorinterface import (
 from neuroconv.utils import calculate_regular_series_rate
 from roiextractors.multiimagingextractor import MultiImagingExtractor
 
-from ..scherrer_ophys.utils import get_timestamps_from_csv, \
-    shift_timestamps_to_start_from_zero
+from ..scherrer_ophys.utils import get_timestamps_from_csv, shift_timestamps_to_start_from_zero
 from .scherrerophysimagingextractor import ScherrerOphysImagingExtractor
 
 

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimaginginterface.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophysimaginginterface.py
@@ -4,7 +4,8 @@ from neuroconv.datainterfaces.ophys.baseimagingextractorinterface import (
 from neuroconv.utils import calculate_regular_series_rate
 from roiextractors.multiimagingextractor import MultiImagingExtractor
 
-from ..scherrer_ophys.utils import get_timestamps_from_csv
+from ..scherrer_ophys.utils import get_timestamps_from_csv, \
+    shift_timestamps_to_start_from_zero
 from .scherrerophysimagingextractor import ScherrerOphysImagingExtractor
 
 
@@ -21,6 +22,7 @@ class ScherrerOphysImagingInterface(BaseImagingExtractorInterface):
         imaging_extractors = [ScherrerOphysImagingExtractor(file_path=file_path) for file_path in ophys_file_paths]
         super().__init__(imaging_extractors=imaging_extractors)
         timestamps = get_timestamps_from_csv(file_path=timestamps_file_path)
+        timestamps = shift_timestamps_to_start_from_zero(timestamps=timestamps)
         if not calculate_regular_series_rate(timestamps):
             # only use timestamps if they are not regular
             self.imaging_extractor.set_times(times=timestamps)

--- a/src/fee_lab_to_nwb/scherrer_ophys/utils.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/utils.py
@@ -1,11 +1,12 @@
 """Utility functions for this dataset."""
 from pathlib import Path
 
+import numpy as np
 from neuroconv.utils import FilePathType
-from pandas import read_csv, to_datetime
+from pandas import read_csv, to_datetime, Series
 
 
-def get_timestamps_from_csv(file_path: FilePathType, adjust_to_zero: bool = True):
+def get_timestamps_from_csv(file_path: FilePathType) -> Series:
     """
     Extracts timestamps from a file.
     """
@@ -18,10 +19,13 @@ def get_timestamps_from_csv(file_path: FilePathType, adjust_to_zero: bool = True
 
     data = read_csv(file_path, sep=" ", header=None, usecols=[0])
 
-    timestamp_in_datetime = to_datetime(data[0])
-    if not adjust_to_zero:
-        return timestamp_in_datetime
-
-    elapsed_time_since_start = timestamp_in_datetime - timestamp_in_datetime.min()
-    timestamps = elapsed_time_since_start.apply(lambda x: x.total_seconds()).to_list()
+    timestamps = to_datetime(data[0])
     return timestamps
+
+
+def shift_timestamps_to_start_from_zero(timestamps: Series) -> np.ndarray:
+    """
+    Returns the elapsed time in seconds since the first timestamp.
+    """
+    elapsed_time_since_start = timestamps - timestamps[0]
+    return np.array(elapsed_time_since_start.apply(lambda x: x.total_seconds()))

--- a/src/fee_lab_to_nwb/scherrer_ophys/utils.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/utils.py
@@ -5,7 +5,7 @@ from neuroconv.utils import FilePathType
 from pandas import read_csv, to_datetime
 
 
-def get_timestamps_from_csv(file_path: FilePathType):
+def get_timestamps_from_csv(file_path: FilePathType, adjust_to_zero: bool = True):
     """
     Extracts timestamps from a file.
     """
@@ -19,7 +19,9 @@ def get_timestamps_from_csv(file_path: FilePathType):
     data = read_csv(file_path, sep=" ", header=None, usecols=[0])
 
     timestamp_in_datetime = to_datetime(data[0])
+    if not adjust_to_zero:
+        return timestamp_in_datetime
+
     elapsed_time_since_start = timestamp_in_datetime - timestamp_in_datetime.min()
     timestamps = elapsed_time_since_start.apply(lambda x: x.total_seconds()).to_list()
-
     return timestamps


### PR DESCRIPTION
Adjust the timestamps of the behavior video to the imaging timestamps. The optical imaging timestamps start earlier, and end shortly after the last timestamp in the behavior timestamps file. 

## Checklist

- [ ] Update `CHANGELOG.md`
