### PR TITLE
Remove key pops from `get_metadata_schema` in `AudioInterface`

### DIFF
--- a/src/fee_lab_to_nwb/general_interfaces/audiointerface.py
+++ b/src/fee_lab_to_nwb/general_interfaces/audiointerface.py
@@ -27,9 +27,6 @@ class AudioInterface(BaseDataInterface):
     def get_metadata_schema(self):
         metadata_schema = super().get_metadata_schema()
         time_series_metadata_schema = get_schema_from_hdmf_class(TimeSeries)
-        exclude = ["conversion", "starting_time", "rate"]
-        for key in exclude:
-            time_series_metadata_schema["properties"].pop(key)
         metadata_schema["properties"]["Behavior"] = get_base_schema(tag="Behavior")
         time_series_metadata_schema.update(required=["name"])
         metadata_schema["properties"]["Behavior"].update(


### PR DESCRIPTION
Testing the repo with fresh environment, the current `AudioInterface` wants to remove keys from `TimeSeries` schema attributes that are not required anymore and doing so results in `KeyError`.  

The testing environment is :
`Python` 3.10
`pynwb` 2.2.0
`neuroconv` 0.2.1
