### PR TITLE
Override `get_image_masks` from custom extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Removed "conversion", "starting_time" and "rate" key pops from TimeSeries metadata schema when
   constructing the metadata schema for `AudioInterface`. [PR #49](https://github.com/catalystneuro/fee-lab-to-nwb/pull/49)
 * Bumped `neuroconv` version to 0.2.2. [PR #52](https://github.com/catalystneuro/fee-lab-to-nwb/pull/52)
+* Override get_image_masks from SegmentationExtractor to be faster when the image masks
+  for all the ROIs are requested. [PR #55](https://github.com/catalystneuro/fee-lab-to-nwb/pull/55)
 
 ### Improvements
 * Create file for tracking changes. [PR #36](https://github.com/catalystneuro/fee-lab-to-nwb/pull/36)

--- a/src/fee_lab_to_nwb/scherrer_ophys/convert_session.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/convert_session.py
@@ -1,6 +1,5 @@
 """Primary script to run to convert an entire session of data using the NWBConverter."""
 from pathlib import Path
-from datetime import datetime
 from zoneinfo import ZoneInfo
 
 from natsort import natsorted

--- a/src/fee_lab_to_nwb/scherrer_ophys/convert_session.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/convert_session.py
@@ -63,7 +63,8 @@ unadjusted_timestamps = shift_timestamps_to_start_from_zero(timestamps=behavior_
 adjusted_timestamps = list(unadjusted_timestamps + offset_in_seconds)
 
 conversion_options = dict(
-    Movie=dict(external_mode=True, timestamps=adjusted_timestamps),
+    Movie=dict(external_mode=True, timestamps=adjusted_timestamps, starting_times=[adjusted_timestamps[0]]),
+    Segmentation=dict(include_roi_acceptance=False),
 )
 
 ophys_dataset_converter = ScherrerOphysNWBConverter(source_data=source_data)

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophyssegmentationextractor.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophyssegmentationextractor.py
@@ -1,0 +1,38 @@
+import numpy as np
+from neuroconv.utils import FilePathType
+from roiextractors.extractors.schnitzerextractor import NewExtractSegmentationExtractor
+
+
+class ScherrerOphysSegmentationExtractor(NewExtractSegmentationExtractor):
+    extractor_name = "ScherrerOphysSegmentationExtractor"
+
+    def __init__(
+        self,
+        file_path: FilePathType,
+        sampling_frequency: float,
+        output_struct_name: str = "output",
+    ):
+        super().__init__(
+            file_path=file_path, sampling_frequency=sampling_frequency, output_struct_name=output_struct_name
+        )
+
+    def get_roi_image_masks(self, roi_ids=None) -> np.ndarray:
+        """Returns the image masks extracted from segmentation algorithm.
+
+        Parameters
+        ----------
+        roi_ids: array_like
+            A list or 1D array of ids of the ROIs. Length is the number of ROIs
+            requested.
+
+        Returns
+        -------
+        image_masks: numpy.ndarray
+            3-D array(val 0 or 1): image_height X image_width X length(roi_ids)
+        """
+        if roi_ids is None:
+            return self._image_masks[:]
+
+        all_ids = self.get_roi_ids()
+        roi_idx_ = [all_ids.index(i) for i in roi_ids]
+        return np.stack([self._image_masks[:, :, k] for k in roi_idx_], 2)

--- a/src/fee_lab_to_nwb/scherrer_ophys/scherrerophyssegmentationinterface.py
+++ b/src/fee_lab_to_nwb/scherrer_ophys/scherrerophyssegmentationinterface.py
@@ -9,9 +9,11 @@ from neuroconv.utils import (
     calculate_regular_series_rate,
 )
 from pynwb import NWBFile
-from roiextractors import ExtractSegmentationExtractor
 from ndx_extract import EXTRACTSegmentation
 
+from fee_lab_to_nwb.scherrer_ophys.scherrerophyssegmentationextractor import (
+    ScherrerOphysSegmentationExtractor,
+)
 from fee_lab_to_nwb.scherrer_ophys.utils import (
     get_timestamps_from_csv,
     shift_timestamps_to_start_from_zero,
@@ -21,7 +23,7 @@ from fee_lab_to_nwb.scherrer_ophys.utils import (
 class ScherrerOphysSegmentationInterface(ExtractSegmentationInterface):
     """Data interface for ExtractSegmentationExtractor."""
 
-    Extractor = ExtractSegmentationExtractor
+    Extractor = ScherrerOphysSegmentationExtractor
 
     def __init__(
         self,
@@ -101,6 +103,7 @@ class ScherrerOphysSegmentationInterface(ExtractSegmentationInterface):
         stub_test: bool = False,
         stub_frames: int = 100,
         include_roi_centroids: bool = True,
+        include_roi_acceptance: bool = True,
         mask_type: Optional[str] = "image",
         iterator_options: Optional[dict] = None,
         compression_options: Optional[dict] = None,
@@ -116,6 +119,7 @@ class ScherrerOphysSegmentationInterface(ExtractSegmentationInterface):
             stub_test=stub_test,
             stub_frames=stub_frames,
             include_roi_centroids=include_roi_centroids,
+            include_roi_acceptance=include_roi_acceptance,
             mask_type=mask_type,
             iterator_options=iterator_options,
             compression_options=compression_options,


### PR DESCRIPTION

- Overrides `get_image_masks` from SegmentationExtractor to return the image masks as is when all the ROIs are requested
- Added an option to skip including accepted/rejected ROIs as in EXTRACT output does not include bad components that were found but then eliminated by default. 
- Fixed the `starting_time` of the movie